### PR TITLE
Refactor AsyncResult to typedef of Future

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ build/
 !**/ios/**/default.mode2v3
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
+
+coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.1.0] - 12/05/2022
+* 100% Test Coverage!!.
+* Refactor `AsyncResult`.
+* Remove deprecated operator `get()`.
+
 ## [3.0.0] - 12/05/2022
 Thanks to [Jacob](https://github.com/jacobaraujo7)
 * Add new operators in Result:

--- a/README.md
+++ b/README.md
@@ -211,35 +211,24 @@ The operators of the **Result** object available in **AsyncResult** are:
 - flatMap
 - pure
 
-Use the **run()** method to run an `AsyncResult<S, E>` turning it into a `Result<S, E>`:
+`AsyncResult<S, E>` is a **typedef** of `Future<Result<S, E>>`.
 
 ```dart
 
-AsyncResult<String, Exception> fetch(){
-    return AsyncResult(() async {
-        await Future.delayer(Duration(second: 1));
-        return Success('Done!');
-    });
+AsyncResult<String, Exception> fetchProducts() async {
+    try {
+      final response = await dio.get('/products');
+      final products = ProductModel.fromList(response.data);
+      return Success(products);
+    } on DioError catch (e) {
+      return Error(ProductException(e.message));
+    }
 }
 
-final result = await fetch().run();
+...
 
-//result now is Result<String, Exception>
-
-```
-
-There are 3 constructors for **AsyncResult**. Are they:
-
-```dart
-// default
-AsyncResult(() async {
-    ...
-});
-
-// with success value
-AsyncResult.success(10);
-
-// with error value
-AsyncResult.error(MyException);
+final state = await fetch()
+    .map((products) => LoadedState(products))
+    .mapLeft((error) => ErrorState(error))
 
 ```

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -80,7 +80,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "3.0.0"
   path:
     dependency: transitive
     description:

--- a/lib/src/async_result.dart
+++ b/lib/src/async_result.dart
@@ -1,71 +1,33 @@
 import '../multiple_result.dart';
 
 /// `AsyncResult<S, E>` represents an asynchronous computation.
-class AsyncResult<S, E> {
-  final Future<Result<S, E>> Function() _run;
+typedef AsyncResult<S, E> = Future<Result<S, E>>;
 
-  /// Build a [AsyncResult] from a function returning a `Future<Result<S, E>>`.
-  AsyncResult(this._run);
-
-  /// Build a [AsyncResult] that returns a [Success].
-  factory AsyncResult.success(S success) {
-    return Success<S, E>(success).toAsyncResult();
-  }
-
-  /// Build a [AsyncResult] that returns a [Error].
-  factory AsyncResult.error(E error) {
-    return Error<S, E>(error).toAsyncResult();
-  }
-
-  /// Run the task and return a `Future<Result<S, E>>`.
-  Future<Result<S, E>> run() => _run();
-
+/// `AsyncResult<S, E>` represents an asynchronous computation.
+extension AsyncResultExtension<S, E> on AsyncResult<S, E> {
   /// Used to chain multiple functions that return a [AsyncResult].
   /// You can extract the value of every [Success] in the chain without
   /// handling all possible missing cases.
   /// If any of the functions in the chain returns [Error],
   /// the result is [Error].
   AsyncResult<W, E> flatMap<W>(AsyncResult<W, E> Function(S success) fn) {
-    return AsyncResult<W, E>(
-      () {
-        return run().then(
-          (result) {
-            return result.when(
-              (success) => fn(success).run(),
-              Error.new,
-            );
-          },
-        );
-      },
-    );
+    return then((result) => result.when(fn, Error.new));
   }
 
   /// If the [AsyncResult] is [Success], then change its value from type `S` to
   /// type `W` using function `fn`.
   AsyncResult<W, E> map<W>(W Function(S success) fn) {
-    return AsyncResult<W, E>(
-      () {
-        return run().then((result) => result.map(fn));
-      },
-    );
+    return then((result) => result.map(fn));
   }
 
   /// If the [AsyncResult] is [Error], then change its value from type `S` to
   /// type `W` using function `fn`.
   AsyncResult<S, W> mapError<W>(W Function(E error) fn) {
-    return AsyncResult<S, W>(
-      () {
-        return run().then((result) => result.mapError(fn));
-      },
-    );
+    return then((result) => result.mapError(fn));
   }
 
   /// Change a [Success] value.
   AsyncResult<W, E> pure<W>(W success) {
-    return AsyncResult<W, E>(
-      () {
-        return run().then((result) => result.pure(success));
-      },
-    );
+    return then((result) => result.pure(success));
   }
 }

--- a/lib/src/result.dart
+++ b/lib/src/result.dart
@@ -17,24 +17,6 @@ abstract class Result<S, E> {
   /// Build a [Result] that returns a [Error].
   factory Result.error(E e) => Error(e);
 
-  /// Returns the current result.
-  ///
-  /// It may be a [Success] or an [Error].
-  /// Check with
-  /// ```dart
-  ///   result.isSuccess();
-  /// ```
-  /// or
-  /// ```dart
-  ///   result.isError();
-  /// ```
-  ///
-  /// before casting the value;
-  @Deprecated('Will be removed in the next version. '
-      'Use `tryGetSuccess` or `tryGetError` instead.'
-      'You may also use `onSuccess` and on `onError` for similar result.')
-  dynamic get();
-
   /// Returns the value of [S] if any.
   S? tryGetSuccess();
 
@@ -92,7 +74,7 @@ abstract class Result<S, E> {
   }
 
   /// Return a [AsyncResult].
-  AsyncResult<S, E> toAsyncResult() => AsyncResult(() async => this);
+  AsyncResult<S, E> toAsyncResult() async => this;
 }
 
 /// Success Result.
@@ -108,11 +90,6 @@ class Success<S, E> extends Result<S, E> {
   );
 
   final S _success;
-
-  @override
-  S get() {
-    return _success;
-  }
 
   @override
   bool isError() => false;
@@ -167,11 +144,6 @@ class Error<S, E> extends Result<S, E> {
   const Error(this._error);
 
   final E _error;
-
-  @override
-  E get() {
-    return _error;
-  }
 
   @override
   bool isError() => true;

--- a/lib/src/unit.dart
+++ b/lib/src/unit.dart
@@ -7,9 +7,6 @@ import 'package:meta/meta.dart';
 @sealed
 class Unit {
   const Unit._();
-
-  @override
-  String toString() => 'Unit';
 }
 
 /// Used instead of `void` as a return statement for a function when

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: multiple_result
 description: Multiple results for dart. Inspired by dartz's Either and Kotlin's sealed classes
-version: 3.0.0
+version: 3.1.0
 repository: https://github.com/higorlapa/result
 
 environment:

--- a/test/src/async_result_test.dart
+++ b/test/src/async_result_test.dart
@@ -1,48 +1,32 @@
-import 'package:multiple_result/src/async_result.dart';
+import 'package:multiple_result/multiple_result.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('AsyncResult.success', () async {
-    final asyncResult = AsyncResult.success(1);
-    final result = await asyncResult.run();
-    expect(result.tryGetSuccess(), 1);
-  });
-
-  test('AsyncResult.error', () async {
-    final asyncResult = AsyncResult.error(1);
-    final result = await asyncResult.run();
-    expect(result.tryGetError(), 1);
-  });
-
   test('flatMap', () async {
-    final result = await AsyncResult //
-            .success(1)
-        .flatMap((success) => AsyncResult.success(success * 2))
-        .run();
+    final result = await Success(1) //
+        .toAsyncResult()
+        .flatMap((success) async => Success(success * 2));
     expect(result.tryGetSuccess(), 2);
   });
 
   test('map', () async {
-    final result = await AsyncResult //
-            .success(1)
-        .map((success) => success * 2)
-        .run();
+    final result = await Success(1) //
+        .toAsyncResult()
+        .map((success) => success * 2);
+
     expect(result.tryGetSuccess(), 2);
   });
 
   test('mapError', () async {
-    final result = await AsyncResult //
-            .error(1)
-        .mapError((error) => error * 2)
-        .run();
+    final result = await Error(1) //
+        .toAsyncResult()
+        .mapError((error) => error * 2);
     expect(result.tryGetError(), 2);
   });
 
   test('pure', () async {
-    final result = await AsyncResult //
-            .success(1)
-        .pure(10)
-        .run();
+    final result = await Success(1).toAsyncResult().pure(10);
+
     expect(result.tryGetSuccess(), 10);
   });
 }

--- a/test/src/result_test.dart
+++ b/test/src/result_test.dart
@@ -47,20 +47,6 @@ void main() {
     expect(value, 2);
   });
 
-  test(
-      'Given a success result, '
-      'When getting the result through get, '
-      'should return the success value', () {
-    final result = useCase();
-
-    MyResult? successResult;
-    if (result.isSuccess()) {
-      successResult = result.get();
-    }
-
-    expect(successResult!.value, isA<String>());
-  });
-
   test('''Given a success result, 
         When getting the result through tryGetSuccess, 
         should return the success value''', () {
@@ -72,6 +58,7 @@ void main() {
     }
 
     expect(successResult!.value, isA<String>());
+    expect(result.isError(), isFalse);
   });
 
   test(''' Given an error result, 
@@ -99,15 +86,7 @@ void main() {
     }
 
     expect(exceptionResult != null, true);
-  });
-
-  test('''
-   Given a result of SuccessResult type, 
-   when getting the result, 
-   should return the success const
-  ''', () {
-    final result = getMockedSuccessResult();
-    expect(result.get(), success);
+    expect(result.isSuccess(), isFalse);
   });
 
   group(
@@ -166,6 +145,14 @@ void main() {
       });
     },
   );
+
+  test('equatable', () {
+    expect(Success(1) == Success(1), isTrue);
+    expect(Success(1).hashCode == Success(1).hashCode, isTrue);
+
+    expect(Error(1) == Error(1), isTrue);
+    expect(Error(1).hashCode == Error(1).hashCode, isTrue);
+  });
 
   group('Map', () {
     test('Success', () {
@@ -267,8 +254,7 @@ class MyException implements Exception {
   int get hashCode => message.hashCode;
 
   @override
-  bool operator ==(Object other) =>
-      other is MyException && other.message == message;
+  bool operator ==(Object other) => other is MyException && other.message == message;
 }
 
 @immutable


### PR DESCRIPTION
- [x] Refactor AsyncResult to typedef of Future
- [x] Remove get() operator (for security monad)
- [x] 100% test coverage
- [x] Update documentation
- [x] Update CHANGELOG
- [x] Update .gitignore
- [x] Change version 3.1.0