### PR TITLE
News operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+## [3.2.0] - 12/08/2022
+
+
+* **Change to `flatMap` in `AsyncResult` allowing synchronous `Result` chaining**:<br>
+We noticed that we can receive a `FutureOr` instead of a `Future` in the `flatMap` anonymous function, more specifically in the `AsyncResult`.
+Now we hope to be able to chain asynchronous and synchronous functions in `AsyncResult`. <br>
+Note that this update only reflects on the `AsyncResult`, this means that the `Result.flatMap` will not change and will still only accept synchronous results(No-Future here).
+
+* **New operators for `Error` result**: <br>
+We have always been supporting `Success` value transformation
+and now we want to show that we care about the flow of errors.<br>
+That's why we added 2 specific operators for `Result` of `Error`:
+   1. `flatMapError`.
+   2. `pureError`
+
+* **Welcome `fold`**:<br>
+`multiple_result` is a proposal based on `Either` from `dartz`, `sealed class` from `Koltin`, in addition to the `Result` objects seen in `Swift` and `Kotlin`. Some developers might be uncomfortable without `fold`. That's why we are bringing `fold` as an alias of `when`, that is, both `when` and `fold` do exactly the same thing!<br>
+Help us figure out which one to remove in the near future.
+
+* **SWAP**:<br>
+This new operand will be useful when you need to swap `Success` and `Error`.
+```dart
+Result<String, int> result =...;
+Result<int, String> newResult = result.swap();
+```
+
+* fix doc
+
+
+
 ## [3.1.0] - 12/05/2022
 * 100% Test Coverage!!.
 * Refactor `AsyncResult`.

--- a/README.md
+++ b/README.md
@@ -90,24 +90,6 @@ void main() {
     });
 ```
 
-#### Handling the Result with `get`
-
-```
-note: [get] is now deprecated and will be removed in the next version.
-```
-
-```dart
-void main() {
-    final result = getSomethingPretty();
-
-    String? mySuccessResult;
-    if (result.isSuccess()) {
-      mySuccessResult = result.get();
-    }
-}
-```
-
-
 #### Handling the Result with `tryGetSuccess`
 
 ```dart

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Result<String, Exception> getSomethingPretty() {
 
 ```
 
-#### Handling the Result with `when`
+#### Handling the Result with `when` or `fold`:
 
 ```dart
 void main() {
@@ -69,6 +69,9 @@ void main() {
 
 }
 ```
+** OBS: As we are going through a transition process, the `when` and `fold` syntax are identical. 
+Use whichever one you feel most comfortable with and help us figure out which one should remain in the pack.
+
 
 #### Handling the Result with `onSuccess` or `onError`
 
@@ -118,6 +121,8 @@ void main() {
 }
 ```
 
+## Transforming a Result
+
 #### Mapping success value with `map`
 
 ```dart
@@ -141,7 +146,7 @@ void main() {
 }
 ```
 
-#### Chain others [Result] with `flatMap`
+#### Chain others [Result] by any `Success` value with `flatMap`
 
 ```dart
 
@@ -158,8 +163,17 @@ void main() {
         .flatMap((s) => checkIsEven(s));
 }
 ```
+#### Chain others [Result] by `Error` value with `flatMapError`
 
-#### Add a pure 'Success' value with `pure`
+```dart
+
+void main() {
+    final result = getNumberResult()
+        .flatMapError((e) => checkError(e));
+}
+```
+
+#### Add a pure `Success` value with `pure`
 
 ```dart
 void main() {
@@ -169,6 +183,25 @@ void main() {
     if (result.isSuccess()) {
       mySuccessResult = result.tryGetSuccess(); // 10
     }
+}
+```
+
+#### Add a pure `Error` value with `pureError`
+
+```dart
+void main() {
+    final result = getSomethingPretty().pureError(10);
+    if (result.isError()) {
+       result.tryGetError(); // 10
+    }
+}
+```
+#### Swap a `Result` with `swap`
+
+```dart
+void main() {
+    Result<String, int> result =...;
+    Result<int, String> newResult = result.swap();
 }
 ```
 
@@ -192,7 +225,10 @@ The operators of the **Result** object available in **AsyncResult** are:
 - map
 - mapError
 - flatMap
+- flatMapError
 - pure
+- pureError
+- swap
 
 `AsyncResult<S, E>` is a **typedef** of `Future<Result<S, E>>`.
 

--- a/README.md
+++ b/README.md
@@ -57,12 +57,13 @@ Result<String, Exception> getSomethingPretty() {
 void main() {
     final result = getSomethingPretty();
      final String message = result.when(
+        (success) {
+          // handle the success here
+          return "success";
+        },
          (error) {
           // handle the error here
           return "error";
-        }, (success) {
-          // handle the success here
-          return "success";
         },
     );
 
@@ -140,7 +141,7 @@ void main() {
 ```dart
 void main() {
     final result = getResult()
-                    .map((e) => MyObject.fromMap(e));
+        .map((e) => MyObject.fromMap(e));
 
     result.tryGetSuccess(); //Instance of 'MyObject' 
 }
@@ -151,7 +152,7 @@ void main() {
 ```dart
 void main() {
     final result = getResult()
-                    .mapError((e) => MyException(e));
+        .mapError((e) => MyException(e));
 
     result.tryGetError(); //Instance of 'MyException'
 
@@ -172,7 +173,7 @@ Result<String, MyException> checkIsEven(String input){
 
 void main() {
     final result = getNumberResult()
-                    .flatMap((s) => checkIsEven(s));
+        .flatMap((s) => checkIsEven(s));
 }
 ```
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -80,7 +80,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.0"
+    version: "3.1.0"
   path:
     dependency: transitive
     description:

--- a/lib/src/async_result.dart
+++ b/lib/src/async_result.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import '../multiple_result.dart';
 
 /// `AsyncResult<S, E>` represents an asynchronous computation.
@@ -5,23 +7,27 @@ typedef AsyncResult<S, E> = Future<Result<S, E>>;
 
 /// `AsyncResult<S, E>` represents an asynchronous computation.
 extension AsyncResultExtension<S, E> on AsyncResult<S, E> {
-  /// Used to chain multiple functions that return a [AsyncResult].
-  /// You can extract the value of every [Success] in the chain without
-  /// handling all possible missing cases.
-  /// If any of the functions in the chain returns [Error],
-  /// the result is [Error].
-  AsyncResult<W, E> flatMap<W>(AsyncResult<W, E> Function(S success) fn) {
+  /// Returns a new `Result`, mapping any `Success` value
+  /// using the given transformation and unwrapping the produced `Result`.
+  AsyncResult<W, E> flatMap<W>(FutureOr<Result<W, E>> Function(S success) fn) {
     return then((result) => result.when(fn, Error.new));
   }
 
-  /// If the [AsyncResult] is [Success], then change its value from type `S` to
-  /// type `W` using function `fn`.
+  /// Returns a new `Result`, mapping any `Error` value
+  /// using the given transformation and unwrapping the produced `Result`.
+  AsyncResult<S, W> flatMapError<W>(
+      FutureOr<Result<S, W>> Function(E error) fn) {
+    return then((result) => result.when(Success.new, fn));
+  }
+
+  /// Returns a new `AsyncResult`, mapping any `Success` value
+  /// using the given transformation.
   AsyncResult<W, E> map<W>(W Function(S success) fn) {
     return then((result) => result.map(fn));
   }
 
-  /// If the [AsyncResult] is [Error], then change its value from type `S` to
-  /// type `W` using function `fn`.
+  /// Returns a new `Result`, mapping any `Error` value
+  /// using the given transformation.
   AsyncResult<S, W> mapError<W>(W Function(E error) fn) {
     return then((result) => result.mapError(fn));
   }
@@ -29,5 +35,16 @@ extension AsyncResultExtension<S, E> on AsyncResult<S, E> {
   /// Change a [Success] value.
   AsyncResult<W, E> pure<W>(W success) {
     return then((result) => result.pure(success));
+  }
+
+  /// Change the [Error] value.
+  AsyncResult<S, W> pureError<W>(W error) {
+    return mapError((_) => error);
+  }
+
+  /// Swap the values contained inside the [Success] and [Error]
+  /// of this [AsyncResult].
+  AsyncResult<E, S> swap() {
+    return then((result) => result.swap());
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: multiple_result
 description: Multiple results for dart. Inspired by dartz's Either and Kotlin's sealed classes
-version: 3.1.0
+version: 3.2.0
 repository: https://github.com/higorlapa/result
 
 environment:

--- a/test/src/async_result_test.dart
+++ b/test/src/async_result_test.dart
@@ -2,11 +2,36 @@ import 'package:multiple_result/multiple_result.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('flatMap', () async {
-    final result = await Success(1) //
-        .toAsyncResult()
-        .flatMap((success) async => Success(success * 2));
-    expect(result.tryGetSuccess(), 2);
+  group('flatMap', () {
+    test('async ', () async {
+      final result = await Success(1) //
+          .toAsyncResult()
+          .flatMap((success) async => Success(success * 2));
+      expect(result.tryGetSuccess(), 2);
+    });
+
+    test('sink', () async {
+      final result = await Success(1) //
+          .toAsyncResult()
+          .flatMap((success) => Success(success * 2));
+      expect(result.tryGetSuccess(), 2);
+    });
+  });
+
+  group('flatMapError', () {
+    test('async ', () async {
+      final result = await Error(1) //
+          .toAsyncResult()
+          .flatMapError((error) async => Error(error * 2));
+      expect(result.tryGetError(), 2);
+    });
+
+    test('sink', () async {
+      final result = await Error(1) //
+          .toAsyncResult()
+          .flatMapError((error) => Error(error * 2));
+      expect(result.tryGetError(), 2);
+    });
   });
 
   test('map', () async {
@@ -28,5 +53,26 @@ void main() {
     final result = await Success(1).toAsyncResult().pure(10);
 
     expect(result.tryGetSuccess(), 10);
+  });
+  test('pureError', () async {
+    final result = await Error(1).toAsyncResult().pureError(10);
+
+    expect(result.tryGetError(), 10);
+  });
+
+  group('swap', () {
+    test('Success to Error', () async {
+      final result = Success<int, String>(0).toAsyncResult();
+      final swap = await result.swap();
+
+      expect(swap.tryGetError(), 0);
+    });
+
+    test('Error to Success', () async {
+      final result = Error<String, int>(0).toAsyncResult();
+      final swap = await result.swap();
+
+      expect(swap.tryGetSuccess(), 0);
+    });
   });
 }


### PR DESCRIPTION
- [x]  **Change to `flatMap` in `AsyncResult` allowing synchronous `Result` chaining**:<br>

We noticed that we can receive a `FutureOr` instead of a `Future` in the `flatMap` anonymous function, more specifically in the `AsyncResult`.
Now we hope to be able to chain asynchronous and synchronous functions in `AsyncResult`. <br>
Note that this update only reflects on the `AsyncResult`, this means that the `Result.flatMap` will not change and will still only accept synchronous results(No-Future here).

- [x] * **New operators for `Error` result**: <br>
We have always been supporting `Success` value transformation
and now we want to show that we care about the flow of errors.<br>
That's why we added 2 specific operators for `Result` of `Error`:
   1. `flatMapError`.
   2. `pureError`

- [x]  **Welcome `fold`**:<br>
`multiple_result` is a proposal based on `Either` from `dartz`, `sealed class` from `Koltin`, in addition to the `Result` objects seen in `Swift` and `Kotlin`. Some developers might be uncomfortable without `fold`. That's why we are bringing `fold` as an alias of `when`, that is, both `when` and `fold` do exactly the same thing!<br>
Help us figure out which one to remove in the near future.

- [x] **SWAP**:<br>
This new operand will be useful when you need to swap `Success` and `Error`.
```dart
Result<String, int> result =...;
Result<int, String> newResult = result.swap();
```

- [x] Fix doc