### PR TITLE
Add AsyncResult operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## [3.2.0] - 12/13/2022
 
+* **Extension to convert any object to the Result type**:
+Use `toSuccess()` and `toError()` method to convert any object (added via extension) into a Result type.
+
+
+```dart
+
+Result<String, Exception> getSomethingPretty() {
+    if(isOk) {
+        return 'OK!'.toSuccess();
+    } else {
+        return Exception('Not Ok!').toError();
+    }
+}
+
+```
 
 * **Change to `flatMap` in `AsyncResult` allowing synchronous `Result` chaining**:<br>
 We noticed that we can receive a `FutureOr` instead of a `Future` in the `flatMap` anonymous function, more specifically in the `AsyncResult`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [3.2.0] - 12/08/2022
+## [3.2.0] - 12/13/2022
 
 
 * **Change to `flatMap` in `AsyncResult` allowing synchronous `Result` chaining**:<br>
@@ -22,6 +22,26 @@ This new operand will be useful when you need to swap `Success` and `Error`.
 ```dart
 Result<String, int> result =...;
 Result<int, String> newResult = result.swap();
+```
+
+* **Added all Result\`s operators in `AsyncResult`**:<br>
+Now, all operators is avaliables in `AsyncResult` include `when`, `fold`, `tryGetSuccess`, `tryGetError`, `isError`, `isSuccess`, `onSuccess` and `onError`.
+
+* **Help with functions that return their parameter**:<br>
+Sometimes it is necessary to return the parameter of the function as in this example:
+```dart
+final result = Success<int, String>(0);
+
+String value = result.when((s) => '$s', (e) => e);
+print(string) // "0";
+```
+Now we can use the `identity` function or its acronym `id` to facilitate the declaration of this type of function that returns its own parameter and does nothing else:
+```dart
+final result = Success<int, String>(0);
+
+// changed `(e) => e` by `id`
+String value = result.when((s) => '$s', id);
+print(string) // "0";
 ```
 
 * fix doc

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Result<String, Exception> getSomethingPretty() {
 
 ```
 
+> NOTE: The `toSuccess()` and `toError()` methods cannot be used on a `Result` object or a `Future`. If you try, will be throw a Assertion Error.
+
+<br>
+
 #### Handling the Result with `when` or `fold`:
 
 ```dart

--- a/README.md
+++ b/README.md
@@ -213,6 +213,24 @@ Some results do not need a specific return. Use the Unit type to signal an empty
     Result<Unit, Exception>
 ```
 
+## Help with functions that return their parameter:
+
+Sometimes it is necessary to return the parameter of the function as in this example:
+```dart
+final result = Success<int, String>(0);
+
+String value = result.when((s) => '$s', (e) => e);
+print(string) // "0";
+```
+Now we can use the `identity` function or its acronym `id` to facilitate the declaration of this type of function that returns its own parameter and does nothing else:
+```dart
+final result = Success<int, String>(0);
+
+// changed `(e) => e` by `id`
+String value = result.when((s) => '$s', id);
+print(string) // "0";
+```
+
 ## Use **AsyncResult** type:
 
 `AsyncResult<S, E>` represents an asynchronous computation.
@@ -220,15 +238,7 @@ Use this component when working with asynchronous **Result**.
 
 **AsyncResult** has some of the operators of the **Result** object to perform data transformations (**Success** or **Error**) before executing the Future.
 
-The operators of the **Result** object available in **AsyncResult** are:
-
-- map
-- mapError
-- flatMap
-- flatMapError
-- pure
-- pureError
-- swap
+All **Result** operators is available in **AsyncResult**
 
 `AsyncResult<S, E>` is a **typedef** of `Future<Result<S, E>>`.
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,27 @@ Result<String, Exception> getSomethingPretty() {
 
 in return of the function, you just need to return
 ```dart
+// Normal instance
 return Success('Something Pretty');
+
+// Result factory
+return Result.success('Something Pretty');
+
+// Using extensions
+return 'Something Pretty'.toSuccess();
 ```
 
 or
 
 ```dart
+// Normal instance
 return Error(Exception('something ugly happened...'));
+
+// Result factory
+return Result.error('something ugly happened...');
+
+// Using extensions
+return 'something ugly happened...'.toError();
 ```
 
 The function should look something like this:
@@ -46,6 +60,19 @@ Result<String, Exception> getSomethingPretty() {
         return Success('OK!');
     } else {
         return Error(Exception('Not Ok!'));
+    }
+}
+
+```
+or this (using extensions):
+
+```dart
+
+Result<String, Exception> getSomethingPretty() {
+    if(isOk) {
+        return 'OK!'.toSuccess();
+    } else {
+        return Exception('Not Ok!').toError();
     }
 }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -80,7 +80,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.2.0"
   path:
     dependency: transitive
     description:

--- a/lib/multiple_result.dart
+++ b/lib/multiple_result.dart
@@ -3,4 +3,5 @@ library multiple_result;
 export 'src/async_result.dart';
 export 'src/function.dart';
 export 'src/result.dart';
+export 'src/result_extension.dart';
 export 'src/unit.dart';

--- a/lib/multiple_result.dart
+++ b/lib/multiple_result.dart
@@ -1,5 +1,6 @@
 library multiple_result;
 
 export 'src/async_result.dart';
+export 'src/function.dart';
 export 'src/result.dart';
 export 'src/unit.dart';

--- a/lib/src/async_result.dart
+++ b/lib/src/async_result.dart
@@ -15,7 +15,8 @@ extension AsyncResultExtension<S, E> on AsyncResult<S, E> {
 
   /// Returns a new `Result`, mapping any `Error` value
   /// using the given transformation and unwrapping the produced `Result`.
-  AsyncResult<S, W> flatMapError<W>(FutureOr<Result<S, W>> Function(E error) fn) {
+  AsyncResult<S, W> flatMapError<W>(
+      FutureOr<Result<S, W>> Function(E error) fn) {
     return then((result) => result.when(Success.new, fn));
   }
 

--- a/lib/src/async_result.dart
+++ b/lib/src/async_result.dart
@@ -15,8 +15,7 @@ extension AsyncResultExtension<S, E> on AsyncResult<S, E> {
 
   /// Returns a new `Result`, mapping any `Error` value
   /// using the given transformation and unwrapping the produced `Result`.
-  AsyncResult<S, W> flatMapError<W>(
-      FutureOr<Result<S, W>> Function(E error) fn) {
+  AsyncResult<S, W> flatMapError<W>(FutureOr<Result<S, W>> Function(E error) fn) {
     return then((result) => result.when(Success.new, fn));
   }
 
@@ -46,5 +45,65 @@ extension AsyncResultExtension<S, E> on AsyncResult<S, E> {
   /// of this [AsyncResult].
   AsyncResult<E, S> swap() {
     return then((result) => result.swap());
+  }
+
+  /// Return the Future result in one of these functions.
+  ///
+  /// if the result is an error, it will be returned in
+  /// [whenError],
+  /// if it is a success it will be returned in [whenSuccess].
+  /// <br><br>
+  /// Same of `fold`
+  Future<W> when<W>(
+    W Function(S success) whenSuccess,
+    W Function(E error) whenError,
+  ) {
+    return then((result) => result.when(whenSuccess, whenError));
+  }
+
+  /// Returns the Future result of onSuccess for the encapsulated value
+  /// if this instance represents `Success` or the result of onError function
+  /// for the encapsulated value if it is `Error`.
+  /// <br><br>
+  /// Same of `when`
+  Future<W> fold<W>(
+    W Function(S success) onSuccess,
+    W Function(E error) onError,
+  ) {
+    return when<W>(onSuccess, onError);
+  }
+
+  /// Returns the future value of [S] if any.
+  Future<S?> tryGetSuccess() {
+    return then((result) => result.tryGetSuccess());
+  }
+
+  /// Returns the future value of [E] if any.
+  Future<E?> tryGetError() {
+    return then((result) => result.tryGetError());
+  }
+
+  /// Returns true if the current result is an [Error].
+  Future<bool> isError() {
+    return then((result) => result.isError());
+  }
+
+  /// Returns true if the current result is a [Success].
+  Future<bool> isSuccess() {
+    return then((result) => result.isSuccess());
+  }
+
+  /// Execute [whenSuccess] if the [Result] is a success.
+  Future<W?> onSuccess<W>(
+    W Function(S success) whenSuccess,
+  ) {
+    return then((result) => result.onSuccess(whenSuccess));
+  }
+
+  /// Execute [whenError] if the [Result] is an error.
+  Future<W?> onError<W>(
+    W Function(E error) whenError,
+  ) {
+    return then((result) => result.onError(whenError));
   }
 }

--- a/lib/src/function.dart
+++ b/lib/src/function.dart
@@ -1,0 +1,35 @@
+/// Returns the given `a`.
+///
+/// Same as `id`.
+///
+/// Shortcut function to return the input parameter:
+/// ```dart
+/// final result = Result<int, String>.success(10);
+///
+/// /// Without using `identity`, you must write a function to return
+/// /// the input parameter `(error) => error`.
+/// final noId = result.when((success) => '$success', (error) => error);
+///
+/// /// Using `identity`/`id`, the function just returns its input parameter.
+/// final withIdentity = result.when((success) => '$success', identity);
+/// final withId = result.when((success) => '$success', identity);
+/// ```
+T identity<T>(T a) => a;
+
+/// Returns the given `a`.
+///
+/// Same as `identity`.
+///
+/// Shortcut function to return the input parameter:
+/// ```dart
+/// final result = Result<int, String>.success(10);
+///
+/// /// Without using `identity`, you must write a function to return
+/// /// the input parameter `(error) => error`.
+/// final noId = result.when((success) => '$success', (error) => error);
+///
+/// /// Using `identity`/`id`, the function just returns its input parameter.
+/// final withIdentity = result.when((success) => '$success', id);
+/// final withId = result.when((success) => '$success', id);
+/// ```
+T id<T>(T a) => a;

--- a/lib/src/result.dart
+++ b/lib/src/result.dart
@@ -55,13 +55,13 @@ abstract class Result<S, E> {
   }
 
   /// Execute [whenSuccess] if the [Result] is a success.
-  R? onSuccess<R>(
-    R Function(S success) whenSuccess,
+  W? onSuccess<W>(
+    W Function(S success) whenSuccess,
   );
 
   /// Execute [whenError] if the [Result] is an error.
-  R? onError<R>(
-    R Function(E error) whenError,
+  W? onError<W>(
+    W Function(E error) whenError,
   );
 
   /// Returns a new `Result`, mapping any `Success` value

--- a/lib/src/result_extension.dart
+++ b/lib/src/result_extension.dart
@@ -1,0 +1,40 @@
+import '../multiple_result.dart';
+
+/// Adds methods for converting any object
+/// into a `Result` type (`Success` or `Error`).
+extension ResultObjectExtends<W> on W {
+  /// Convert the object to a `Result` type [Error].
+  ///
+  /// Will throw an error if used on a `Result` or `Future` instance.
+  Error<S, W> toError<S>() {
+    assert(
+      this is! Result,
+      'Don`t use the "toError()" method '
+      'on instances of the Result.',
+    );
+    assert(
+      this is! Future,
+      'Don`t use the "toError()" method '
+      'on instances of the Future.',
+    );
+
+    return Error<S, W>(this);
+  }
+
+  /// Convert the object to a `Result` type [SUccess].
+  ///
+  /// Will throw an error if used on a `Result` or `Future` instance.
+  Success<W, E> toSuccess<E>() {
+    assert(
+      this is! Result,
+      'Don`t use the "toSuccess()" method '
+      'on instances of the Result.',
+    );
+    assert(
+      this is! Future,
+      'Don`t use the "toSuccess()" method '
+      'on instances of the Future.',
+    );
+    return Success<W, E>(this);
+  }
+}

--- a/lib/src/result_extension.dart
+++ b/lib/src/result_extension.dart
@@ -2,7 +2,7 @@ import '../multiple_result.dart';
 
 /// Adds methods for converting any object
 /// into a `Result` type (`Success` or `Error`).
-extension ResultObjectExtends<W> on W {
+extension ResultObjectExtension<W> on W {
   /// Convert the object to a `Result` type [Error].
   ///
   /// Will throw an error if used on a `Result` or `Future` instance.

--- a/test/src/async_result_test.dart
+++ b/test/src/async_result_test.dart
@@ -75,4 +75,72 @@ void main() {
       expect(swap.tryGetSuccess(), 0);
     });
   });
+
+  group('when', () {
+    test('Success', () async {
+      final result = Success<int, String>(0).toAsyncResult();
+      final futureValue = result.when(((success) => success), (e) => -1);
+      expect(futureValue, completion(0));
+    });
+
+    test('Error', () async {
+      final result = Error<String, int>(0).toAsyncResult();
+      final futureValue = result.when(((success) => -1), (e) => e);
+      expect(futureValue, completion(0));
+    });
+  });
+
+  group('fold', () {
+    test('Success', () async {
+      final result = Success<int, String>(0).toAsyncResult();
+      final futureValue = result.fold(((success) => success), (e) => -1);
+      expect(futureValue, completion(0));
+    });
+
+    test('Error', () async {
+      final result = Error<String, int>(0).toAsyncResult();
+      final futureValue = result.fold(((success) => -1), (e) => e);
+      expect(futureValue, completion(0));
+    });
+  });
+
+  group('tryGetSuccess and tryGetError', () {
+    test('Success', () async {
+      final result = Success<int, String>(0).toAsyncResult();
+
+      expect(result.isSuccess(), completion(true));
+      expect(result.tryGetSuccess(), completion(0));
+    });
+
+    test('Error', () async {
+      final result = Error<String, int>(0).toAsyncResult();
+
+      expect(result.isError(), completion(true));
+      expect(result.tryGetError(), completion(0));
+    });
+  });
+
+  group('onSuccess', () {
+    test('Success', () async {
+      final result = Success<int, String>(0).toAsyncResult();
+      expect(result.onSuccess((success) => success), completion(0));
+    });
+
+    test('Error', () async {
+      final result = Error<String, int>(0).toAsyncResult();
+      expect(result.onSuccess((success) => success), completion(isNull));
+    });
+  });
+
+  group('onError', () {
+    test('Success', () async {
+      final result = Success<int, String>(0).toAsyncResult();
+      expect(result.onError((error) => error), completion(isNull));
+    });
+
+    test('Error', () async {
+      final result = Error<String, int>(0).toAsyncResult();
+      expect(result.onError((error) => error), completion(0));
+    });
+  });
 }

--- a/test/src/result_extension_test.dart
+++ b/test/src/result_extension_test.dart
@@ -1,0 +1,57 @@
+import 'package:multiple_result/src/result.dart';
+import 'package:multiple_result/src/result_extension.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('toError', () {
+    test('without result type', () {
+      final result = 'error'.toError();
+
+      expect(result, isA<Result<dynamic, String>>());
+      expect(result.tryGetError(), isA<String>());
+      expect(result.tryGetError(), 'error');
+    });
+
+    test('with result type', () {
+      Result<int, String> result = 'error'.toError();
+
+      expect(result, isA<Result<int, String>>());
+      expect(result.tryGetError(), isA<String>());
+      expect(result.tryGetError(), 'error');
+    });
+
+    test('throw AssertException if is a Result object', () {
+      Result<int, String> result = 'error'.toError();
+      expect(result.toError, throwsA(isA<AssertionError>()));
+    });
+
+    test('throw AssertException if is a Future object', () {
+      expect(Future.value().toError, throwsA(isA<AssertionError>()));
+    });
+  });
+
+  group('toSuccess', () {
+    test('without result type', () {
+      final result = 'success'.toSuccess();
+
+      expect(result, isA<Result<String, dynamic>>());
+      expect(result.tryGetSuccess(), 'success');
+    });
+
+    test('with result type', () {
+      Result<String, int> result = 'success'.toSuccess();
+
+      expect(result, isA<Result<String, int>>());
+      expect(result.tryGetSuccess(), 'success');
+    });
+
+    test('throw AssertException if is a Result object', () {
+      final result = 'success'.toSuccess();
+      expect(result.toSuccess, throwsA(isA<AssertionError>()));
+    });
+
+    test('throw AssertException if is a Future object', () {
+      expect(Future.value().toSuccess, throwsA(isA<AssertionError>()));
+    });
+  });
+}

--- a/test/src/result_test.dart
+++ b/test/src/result_test.dart
@@ -308,10 +308,24 @@ void main() {
       expect(swap.tryGetSuccess(), 0);
     });
   });
+
+  group('fold', () {
+    test('Success', () {
+      final result = Success<int, String>(0);
+      final futureValue = result.fold(id, (e) => -1);
+      expect(futureValue, 0);
+    });
+
+    test('Error', () {
+      final result = Error<String, int>(0);
+      final futureValue = result.fold(((success) => -1), identity);
+      expect(futureValue, 0);
+    });
+  });
 }
 
-Result<SuccessResult, MyException> getMockedSuccessResult() {
-  return Success(success);
+Result<Unit, MyException> getMockedSuccessResult() {
+  return Success.unit();
 }
 
 class MyUseCase {


### PR DESCRIPTION
Add Result operators to AsyncResult:

- [x] when
- [x] fold
- [x] tryGetSuccess
- [x] tryGetError
- [x] isError
- [x] isSuccess
- [x] onSuccess
- [x] onError
- [x] Added toError and toSuccess methods via extension
- [x] Create identity function for function returning own parameter (`id`/`identity`)
- [x] Fix tests
- [x] Fix doc 
- [x] Fix changelog